### PR TITLE
Change default app title to Alpollo

### DIFF
--- a/src/main/webapp/public/index.html
+++ b/src/main/webapp/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Alpollo</title>
     <link rel="preload" as="font" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <style>
       body {


### PR DESCRIPTION
<img width="1790" alt="Screen Shot 2020-08-25 at 10 27 12" src="https://user-images.githubusercontent.com/41622701/91145323-f1504b00-e6bd-11ea-9aef-29cb60898948.png">
That's why I haven't noticed that the name of the tab was "React App"