### PR TITLE
Replace charts with React

### DIFF
--- a/src/main/java/com/google/alpollo/EntityServlet.java
+++ b/src/main/java/com/google/alpollo/EntityServlet.java
@@ -31,7 +31,7 @@ public class EntityServlet extends HttpServlet {
       List<SongEntity> topSalientEntities = AnalysisHelper.getTopSalientEntities(simplifiedEntityList);
 
       String json = gson.toJson(topSalientEntities);
-      response.setContentType("application/json;");
+      response.setContentType("application/json; charset=UTF-8");
       response.getWriter().println(json);
     } catch (IllegalStateException | IOException entityException) {
         response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -13,7 +13,8 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.3",
     "react-router-dom": "5.2.0",
-    "react-youtube": "7.11.3"
+    "react-youtube": "7.11.3",
+    "react-google-charts": "3.0.15"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/main/webapp/public/index.html
+++ b/src/main/webapp/public/index.html
@@ -57,6 +57,5 @@
         console.log('service worker is not supported');
       }
     </script>
-    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
   </body>
 </html>

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -4,6 +4,7 @@ import { withStyles } from "@material-ui/styles";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import axios from "axios";
 import Chart from "react-google-charts";
+import Typography from "@material-ui/core/Typography";
 
 const google = window.google;
 
@@ -83,27 +84,45 @@ class EntityAnalysisInfo extends React.Component {
       return <p>No entities were found.</p>;
     }
 
-    /** Gather the most important words in a simple array */
+    /** Gather the most important words and their data in simple arrays */
     var top10WordsData = [];
+    var top10WordsLinks = [];
     top10WordsData.push(['Word and Type', 'Importance'])
     this.state.entityAnalysisInfo.forEach((entity) => {
       top10WordsData.push([entity.name + ' (' + entity.type + ')', entity.salience]);
+      if (entity.wikiLink !== "") {
+        top10WordsLinks.push(entity.wikiLink);
+      }
     })
+
+    const listLinks = top10WordsLinks.map((link, index) =>
+      <li key={index + 1}>
+        <a href={link}> {link} </a>
+      </li>
+    );
      
  
     return (
-      <div style={{ display: 'flex', maxWidth: 900 }}>
-        <Chart
-          width={800}
-          height={400}
-          chartType="PieChart"
-          loader={<div>Loading Chart</div>}
-          data={top10WordsData}
-          options={{
-            title: 'Most Important Words',
-          }}
-          legendToggle
-        />
+      <div>
+        <div style={{ display: 'flex', maxWidth: 900 }}>
+          <Chart
+            width={800}
+            height={400}
+            chartType="PieChart"
+            loader={<div>Loading Chart</div>}
+            data={top10WordsData}
+            options={{
+              title: 'Most Important Words',
+            }}
+            legendToggle
+          />
+        </div>
+        <div>
+        <Typography variant="h5">Wiki links found</Typography>
+          <ul>
+            {listLinks}         
+          </ul>
+        </div>
       </div>
     );
   }

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -82,7 +82,7 @@ class EntityAnalysisInfo extends React.Component {
       return <p>No entities were found.</p>;
     }
 
-    /** Gather the most important words and their data in simple arrays */
+    /** Gather the most important words and their data in simple arrays. */
     var top10WordsData = [];
     var top10WordsLinks = [];
     top10WordsData.push(['Word and Type', 'Importance'])
@@ -99,7 +99,6 @@ class EntityAnalysisInfo extends React.Component {
       </li>
     );
      
- 
     return (
       <div>
         <div style={{ display: 'flex', maxWidth: 900 }}>

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -84,11 +84,11 @@ class EntityAnalysisInfo extends React.Component {
     }
 
        /** Gather the most important words in a simple array */
-       var top10WordsData = [];
-       top10WordsData.push(['Word and Type', 'Importance'])
-       this.state.entityAnalysisInfo.forEach((entity) => {
-           top10WordsData.push([entity.name + ' (' + entity.type + ')', entity.salience]);
-       })
+      var top10WordsData = [];
+      top10WordsData.push(['Word and Type', 'Importance'])
+      this.state.entityAnalysisInfo.forEach((entity) => {
+        top10WordsData.push([entity.name + ' (' + entity.type + ')', entity.salience]);
+      })
      
  
      return (

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -103,7 +103,7 @@ class EntityAnalysisInfo extends React.Component {
       <div>
         <div style={{ display: 'flex', maxWidth: 900 }}>
           <Chart
-            width={800}
+            width={1200}
             height={400}
             chartType="PieChart"
             loader={<div>Loading Chart</div>}

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -6,8 +6,6 @@ import axios from "axios";
 import Chart from "react-google-charts";
 import Typography from "@material-ui/core/Typography";
 
-const google = window.google;
-
 const styles = (theme) => ({
   root: {
     display: "flex",

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -94,8 +94,8 @@ class EntityAnalysisInfo extends React.Component {
      return (
        <div style={{ display: 'flex', maxWidth: 900 }}>
          <Chart
-           width={600}
-           height={600}
+           width={800}
+           height={400}
            chartType="PieChart"
            loader={<div>Loading Chart</div>}
            data={top10WordsData}

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/styles";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import axios from "axios";
+import Chart from "react-google-charts";
 
 const google = window.google;
 
@@ -82,47 +83,31 @@ class EntityAnalysisInfo extends React.Component {
       return <p>No entities were found.</p>;
     }
 
-    /**
-     * Function will draw a pie chart with static data representing the most important words in
-     * our song's context.
-     */
-    const drawTop10WordsChart = (element) => {
-      const data = new google.visualization.DataTable();
-      data.addColumn("string", "Name");
-      data.addColumn("number", "Salience");
-      this.state.entityAnalysisInfo.forEach((entity) => {
-        data.addRow([entity.name, entity.salience]);
-      });
-
-      const options = {
-        title: "Most important words",
-        width: 600,
-        height: 500,
-      };
-
-      const entityChart = new google.visualization.PieChart(element);
-      entityChart.draw(data, options);
-    }
-
-    const loadChartAPI = (element) => {
-      // Load the Visualization API and the corechart package.
-      google.charts.load("current", { packages: ["corechart"] });
-
-      // Set a callback to run when the Google Visualization API is loaded.
-      google.charts.setOnLoadCallback(function () {
-        drawTop10WordsChart(element);
-      });
-    }
-
-    return (
-      <div
-        ref={(elem) => {
-          if (elem) loadChartAPI(elem);
-        }}
-      ></div>
-    );
-  }
-}
+       /** Gather the most important words in a simple array */
+       var top10WordsData = [];
+       top10WordsData.push(['Word and Type', 'Importance'])
+       this.state.entityAnalysisInfo.forEach((entity) => {
+           top10WordsData.push([entity.name + ' (' + entity.type + ')', entity.salience]);
+       })
+     
+ 
+     return (
+       <div style={{ display: 'flex', maxWidth: 900 }}>
+         <Chart
+           width={600}
+           height={600}
+           chartType="PieChart"
+           loader={<div>Loading Chart</div>}
+           data={top10WordsData}
+           options={{
+             title: 'Most Important Words',
+           }}
+           legendToggle
+         />
+       </div>
+     );
+   }
+ }
 
 EntityAnalysisInfo.propTypes = {
   classes: PropTypes.object.isRequired,

--- a/src/main/webapp/src/components/entityAnalysisInfo.js
+++ b/src/main/webapp/src/components/entityAnalysisInfo.js
@@ -83,31 +83,31 @@ class EntityAnalysisInfo extends React.Component {
       return <p>No entities were found.</p>;
     }
 
-       /** Gather the most important words in a simple array */
-      var top10WordsData = [];
-      top10WordsData.push(['Word and Type', 'Importance'])
-      this.state.entityAnalysisInfo.forEach((entity) => {
-        top10WordsData.push([entity.name + ' (' + entity.type + ')', entity.salience]);
-      })
+    /** Gather the most important words in a simple array */
+    var top10WordsData = [];
+    top10WordsData.push(['Word and Type', 'Importance'])
+    this.state.entityAnalysisInfo.forEach((entity) => {
+      top10WordsData.push([entity.name + ' (' + entity.type + ')', entity.salience]);
+    })
      
  
-     return (
-       <div style={{ display: 'flex', maxWidth: 900 }}>
-         <Chart
-           width={800}
-           height={400}
-           chartType="PieChart"
-           loader={<div>Loading Chart</div>}
-           data={top10WordsData}
-           options={{
-             title: 'Most Important Words',
-           }}
-           legendToggle
-         />
-       </div>
-     );
-   }
- }
+    return (
+      <div style={{ display: 'flex', maxWidth: 900 }}>
+        <Chart
+          width={800}
+          height={400}
+          chartType="PieChart"
+          loader={<div>Loading Chart</div>}
+          data={top10WordsData}
+          options={{
+            title: 'Most Important Words',
+          }}
+          legendToggle
+        />
+      </div>
+    );
+  }
+}
 
 EntityAnalysisInfo.propTypes = {
   classes: PropTypes.object.isRequired,


### PR DESCRIPTION
New React chart looks about the same, but it takes less code.

Besides name and salience, I added the type of the entity too in parentheses. The size of the chart might need a bit more fine tuning. It takes a bit too much space in the left side.