### PR TITLE
Move files in com.google.alpollo to the separate packages for logic

### DIFF
--- a/src/main/java/com/google/alpollo/database/ObjectifyWebFilter.java
+++ b/src/main/java/com/google/alpollo/database/ObjectifyWebFilter.java
@@ -1,3 +1,5 @@
+package com.google.alpollo.database;
+
 import javax.servlet.annotation.WebFilter;
 import com.googlecode.objectify.ObjectifyFilter;
 

--- a/src/main/java/com/google/alpollo/database/OfyService.java
+++ b/src/main/java/com/google/alpollo/database/OfyService.java
@@ -1,4 +1,4 @@
-package com.google.alpollo;
+package com.google.alpollo.database;
 
 import com.googlecode.objectify.Objectify;
 import com.googlecode.objectify.ObjectifyFactory;

--- a/src/main/java/com/google/alpollo/database/SongDataBase.java
+++ b/src/main/java/com/google/alpollo/database/SongDataBase.java
@@ -1,6 +1,8 @@
-package com.google.alpollo;
+package com.google.alpollo.database;
 
 import java.util.List;
+
+import com.google.alpollo.database.OfyService;
 import com.google.alpollo.model.AnalysisInfo;
 import com.google.alpollo.model.Song;
 import com.google.alpollo.model.SongCounter;

--- a/src/main/java/com/google/alpollo/helpers/AnalysisHelper.java
+++ b/src/main/java/com/google/alpollo/helpers/AnalysisHelper.java
@@ -1,4 +1,4 @@
-package com.google.alpollo;
+package com.google.alpollo.helpers;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/google/alpollo/helpers/ConfigHelper.java
+++ b/src/main/java/com/google/alpollo/helpers/ConfigHelper.java
@@ -1,4 +1,4 @@
-package com.google.alpollo;
+package com.google.alpollo.helpers;
 
 import com.google.gson.Gson;
 import java.io.*;

--- a/src/main/java/com/google/alpollo/helpers/YouTubeService.java
+++ b/src/main/java/com/google/alpollo/helpers/YouTubeService.java
@@ -1,4 +1,4 @@
-package com.google.alpollo;
+package com.google.alpollo.helpers;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;

--- a/src/main/java/com/google/alpollo/model/Lyrics.java
+++ b/src/main/java/com/google/alpollo/model/Lyrics.java
@@ -1,10 +1,13 @@
 package com.google.alpollo.model;
 
+import com.google.alpollo.servlets.EntityServlet;
+import com.google.alpollo.servlets.SentimentServlet;
+
 /**
  * Class that contains only lyrics field.
  * Represents body request of the next servlets:
- * @see com.google.alpollo.SentimentServlet
- * @see com.google.alpollo.EntityServlet
+ * @see SentimentServlet
+ * @see EntityServlet
  *
  * Used only for deserialization.
  */

--- a/src/main/java/com/google/alpollo/model/SongSentiment.java
+++ b/src/main/java/com/google/alpollo/model/SongSentiment.java
@@ -1,6 +1,6 @@
 package com.google.alpollo.model;
 
-import com.google.alpollo.AnalysisHelper;
+import com.google.alpollo.helpers.AnalysisHelper;
 
 /**
  * Class created to store only sentiment score and magnitude, leaving the other

--- a/src/main/java/com/google/alpollo/servlets/AnalysisInfoServlet.java
+++ b/src/main/java/com/google/alpollo/servlets/AnalysisInfoServlet.java
@@ -1,10 +1,12 @@
-package com.google.alpollo;
+package com.google.alpollo.servlets;
 
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.alpollo.database.SongDataBase;
 import com.google.alpollo.model.AnalysisInfo;
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;

--- a/src/main/java/com/google/alpollo/servlets/AuthenticationServlet.java
+++ b/src/main/java/com/google/alpollo/servlets/AuthenticationServlet.java
@@ -1,4 +1,4 @@
-package com.google.alpollo;
+package com.google.alpollo.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;

--- a/src/main/java/com/google/alpollo/servlets/EntityServlet.java
+++ b/src/main/java/com/google/alpollo/servlets/EntityServlet.java
@@ -1,4 +1,4 @@
-package com.google.alpollo;
+package com.google.alpollo.servlets;
 
 import java.io.IOException;
 import java.util.List;
@@ -6,6 +6,9 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.alpollo.helpers.AnalysisHelper;
+import com.google.alpollo.helpers.ConfigHelper;
 import com.google.alpollo.model.Lyrics;
 import com.google.alpollo.model.SongEntity;
 import com.google.cloud.language.v1.Entity;

--- a/src/main/java/com/google/alpollo/servlets/SentimentServlet.java
+++ b/src/main/java/com/google/alpollo/servlets/SentimentServlet.java
@@ -1,10 +1,13 @@
-package com.google.alpollo;
+package com.google.alpollo.servlets;
 
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.alpollo.helpers.AnalysisHelper;
+import com.google.alpollo.helpers.ConfigHelper;
 import com.google.alpollo.model.Lyrics;
 import com.google.alpollo.model.SongSentiment;
 import com.google.cloud.language.v1.Sentiment;

--- a/src/main/java/com/google/alpollo/servlets/TopSongsServlet.java
+++ b/src/main/java/com/google/alpollo/servlets/TopSongsServlet.java
@@ -1,5 +1,6 @@
-package com.google.alpollo;
+package com.google.alpollo.servlets;
 
+import com.google.alpollo.database.SongDataBase;
 import com.google.alpollo.model.SongCounter;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;

--- a/src/main/java/com/google/alpollo/servlets/YouTubeServlet.java
+++ b/src/main/java/com/google/alpollo/servlets/YouTubeServlet.java
@@ -1,5 +1,7 @@
-package com.google.alpollo;
+package com.google.alpollo.servlets;
 
+import com.google.alpollo.helpers.ConfigHelper;
+import com.google.alpollo.helpers.YouTubeService;
 import com.google.api.services.youtube.YouTube;
 import com.google.api.services.youtube.model.SearchListResponse;
 import com.google.gson.Gson;

--- a/src/test/java/com/google/alpollo/AnalysisTest.java
+++ b/src/test/java/com/google/alpollo/AnalysisTest.java
@@ -1,7 +1,10 @@
 package com.google.alpollo;
 
+import com.google.alpollo.helpers.AnalysisHelper;
 import com.google.alpollo.model.Lyrics;
 import com.google.alpollo.model.SongSentiment;
+import com.google.alpollo.servlets.EntityServlet;
+import com.google.alpollo.servlets.SentimentServlet;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
Since we have a lot of files in com.google.alpollo, it would be good to split them in different folders based on their role: model, servlets, helpers and database 